### PR TITLE
use given _id instead of autoinc

### DIFF
--- a/libs/model.js
+++ b/libs/model.js
@@ -48,14 +48,16 @@ class Model {
         return new Promise(async(resolve, reject) => {
             try {
                 var autoinc = this.model.autoinc;
-                data._id = autoinc;
-                this.model.rows[autoinc] = data;
-                this.model.autoinc += 1;
+                data._id = data._id ? data._id : autoinc++;
+                if (this.model.rows[data._id]) {
+                    return Util.error("ReactNativeStore error: Storage already contains _id '" + data._id + "'");
+                }
+                this.model.rows[data._id] = data;
                 this.model.totalrows += 1;
 
                 this.database[this.modelName] = this.model;
                 await AsyncStorage.setItem(this.dbName, JSON.stringify(this.database));
-                resolve(this.model.rows[autoinc]);
+                resolve(this.model.rows[data._id]);
             } catch (error) {
                 Util.error('ReactNativeStore error: ' + error.message);
             }


### PR DESCRIPTION
If the object that should be added contains an _id, it will be used as id instead of autoinc.
An error will be returned, if the given _id is already stored in the database
